### PR TITLE
Add dark mode support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,15 @@
-import { Inter } from "next/font/google"
-import "./globals.css"
-import { ThemeProvider } from "@/components/theme/theme-provider"
+import './globals.css'
+import { Inter } from 'next/font/google'
+import { Suspense } from 'react'
+import { Analytics } from '@/components/Analytics';
+import { ThemeProvider } from '@/components/theme/theme-provider'
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata = {
+  title: 'Don\'t Sign Until You\'re Sure | AI Contract Analysis',
+  description: 'Upload your contract and let AI highlight the risks and key terms before you sign.',
+}
 
 export default function RootLayout({
   children,
@@ -11,10 +18,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head />
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
+          <Suspense>
+            <Analytics />
+          </Suspense>
         </ThemeProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,8 @@
-import './globals.css'
-import { Inter } from 'next/font/google'
-import { Suspense } from 'react'
-import { Analytics } from '@/components/Analytics';
+import { Inter } from "next/font/google"
+import "./globals.css"
+import { ThemeProvider } from "@/components/theme/theme-provider"
 
-const inter = Inter({ subsets: ['latin'] })
-
-export const metadata = {
-  title: 'Don\'t Sign Until You\'re Sure | AI Contract Analysis',
-  description: 'Upload your contract and let AI highlight the risks and key terms before you sign.',
-}
+const inter = Inter({ subsets: ["latin"] })
 
 export default function RootLayout({
   children,
@@ -16,12 +10,12 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head />
       <body className={inter.className}>
-        {children}
-        <Suspense>
-          <Analytics />
-        </Suspense>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,21 @@
-import { Hero } from "@/components/hero"
-import { ThemeToggle } from "@/components/theme/theme-toggle"
+import Header from '@/components/header'
+import Hero from '@/components/hero/Hero'
+import HowItWorks from '@/components/how-it-works'
+import KeyFeatures from '@/components/key-features'
+import Footer from '@/components/footer'
+import { ThemeToggle } from '@/components/theme/theme-toggle'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <ThemeToggle />
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-green-50 to-blue-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <div className="fixed top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
+      <Header />
       <Hero />
+      <HowItWorks />
+      <KeyFeatures />
+      <Footer />
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,11 @@
-import Header from '@/components/header'
-import Hero from '@/components/hero/Hero'
-import HowItWorks from '@/components/how-it-works'
-import KeyFeatures from '@/components/key-features'
-import Footer from '@/components/footer'
+import { Hero } from "@/components/hero"
+import { ThemeToggle } from "@/components/theme/theme-toggle"
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-green-50 to-blue-50">
-      <Header />
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <ThemeToggle />
       <Hero />
-      <HowItWorks />
-      <KeyFeatures />
-      <Footer />
     </main>
   )
 }

--- a/components/analysis-results/AnalysisResults.tsx
+++ b/components/analysis-results/AnalysisResults.tsx
@@ -9,37 +9,37 @@ interface AnalysisResultsProps {
 export function AnalysisResults({ analysis }: AnalysisResultsProps) {
   return (
     <div className="mt-8 space-y-6">
-      <div className="px-6 py-4 bg-white rounded-lg shadow-sm border border-gray-100">
-        <h2 className="text-2xl font-bold mb-4 text-gray-900">Analysis Summary</h2>
-        <p className="text-gray-700 text-lg leading-relaxed">{analysis.summary}</p>
+      <div className="px-6 py-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">Analysis Summary</h2>
+        <p className="text-gray-700 dark:text-gray-300 text-lg leading-relaxed">{analysis.summary}</p>
       </div>
 
       <AnalysisSection 
         title="Key Terms"
         items={analysis.keyTerms}
-        icon={<CheckCircle className="w-5 h-5 text-blue-500" />}
+        icon={<CheckCircle className="w-5 h-5 text-blue-500 dark:text-blue-400" />}
       />
 
       <AnalysisSection 
         title="Potential Risks"
         items={analysis.potentialRisks}
-        icon={<AlertTriangle className="w-5 h-5 text-red-500" />}
+        icon={<AlertTriangle className="w-5 h-5 text-red-500 dark:text-red-400" />}
       />
 
       <AnalysisSection 
         title="Important Clauses"
         items={analysis.importantClauses}
-        icon={<FileText className="w-5 h-5 text-gray-500" />}
+        icon={<FileText className="w-5 h-5 text-gray-500 dark:text-gray-400" />}
       />
 
       <AnalysisSection 
         title="Recommendations"
         items={analysis.recommendations}
-        icon={<Clock className="w-5 h-5 text-green-500" />}
+        icon={<Clock className="w-5 h-5 text-green-500 dark:text-green-400" />}
       />
 
       {analysis.metadata && (
-        <div className="px-6 py-4 bg-gray-50 rounded-lg text-sm text-gray-500 space-y-1">
+        <div className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg text-sm text-gray-500 dark:text-gray-400 space-y-1">
           <p>Analysis completed on: {new Date(analysis.metadata.analyzedAt).toLocaleString()}</p>
           {analysis.metadata.totalChunks && (
             <p>Document sections analyzed: {analysis.metadata.totalChunks}</p>

--- a/components/analysis-results/AnalysisSection.tsx
+++ b/components/analysis-results/AnalysisSection.tsx
@@ -8,14 +8,14 @@ export function AnalysisSection({ title, items, icon }: AnalysisSectionProps) {
   if (!items || items.length === 0) return null;
   
   return (
-    <div className="mb-6 px-6 py-4 bg-white rounded-lg shadow-sm border border-gray-100">
-      <h3 className="text-lg font-semibold mb-3 flex items-center gap-2 text-gray-900">
+    <div className="mb-6 px-6 py-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
+      <h3 className="text-lg font-semibold mb-3 flex items-center gap-2 text-gray-900 dark:text-white">
         {icon}
         {title}
       </h3>
       <ul className="list-disc pl-6 space-y-2">
         {items.map((item, index) => (
-          <li key={index} className="text-gray-700">{item}</li>
+          <li key={index} className="text-gray-700 dark:text-gray-300">{item}</li>
         ))}
       </ul>
     </div>

--- a/components/contract-analysis/AnalysisButton.tsx
+++ b/components/contract-analysis/AnalysisButton.tsx
@@ -13,7 +13,7 @@ export function AnalysisButton({ isDisabled, isAnalyzing, onClick }: AnalysisBut
       variant="default"
       disabled={isDisabled}
       onClick={onClick}
-      className="bg-blue-600 hover:bg-blue-700 text-white px-6"
+      className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white px-6"
     >
       {isAnalyzing ? (
         <>

--- a/components/contract-analysis/AnalysisProgress.tsx
+++ b/components/contract-analysis/AnalysisProgress.tsx
@@ -4,18 +4,20 @@ interface AnalysisProgressProps {
   currentChunk: number;
   totalChunks: number;
   isAnalyzing: boolean;
+  stage: 'preprocessing' | 'analyzing' | 'complete';
+  progress: number;
 }
 
-export function AnalysisProgress({ currentChunk, totalChunks, isAnalyzing }: AnalysisProgressProps) {
+export function AnalysisProgress({ currentChunk, totalChunks, isAnalyzing, stage, progress }: AnalysisProgressProps) {
   // Show progress bar while analyzing or if we have any progress
   if (!isAnalyzing && currentChunk === 0) return null;
 
-  const progress = totalChunks > 0 ? Math.round((currentChunk / totalChunks) * 100) : 0;
+  const calculatedProgress = totalChunks > 0 ? Math.round((currentChunk / totalChunks) * 100) : 0;
   const isComplete = currentChunk === totalChunks && totalChunks > 0;
   
   return (
     <div className="w-full max-w-md mx-auto mt-4 space-y-2">
-      <div className="flex justify-between text-sm text-gray-600">
+      <div className="flex justify-between text-sm text-gray-600 dark:text-gray-300">
         <span>
           {isComplete 
             ? 'Analysis complete!' 
@@ -23,15 +25,15 @@ export function AnalysisProgress({ currentChunk, totalChunks, isAnalyzing }: Ana
               ? 'Starting analysis...'
               : 'Analyzing contract...'}
         </span>
-        <span>{progress}%</span>
+        <span>{calculatedProgress}%</span>
       </div>
       <Progress 
-        value={progress} 
+        value={calculatedProgress} 
         className="h-2"
-        indicatorColor={isComplete ? 'bg-green-600' : 'bg-blue-600'}
+        indicatorColor={isComplete ? 'bg-green-600 dark:bg-green-500' : 'bg-blue-600 dark:bg-blue-500'}
       />
       {(currentChunk > 0 || totalChunks > 0) && (
-        <p className="text-sm text-gray-500 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
           Processing section {currentChunk} of {totalChunks}
         </p>
       )}

--- a/components/contract-upload/FileUploadArea.tsx
+++ b/components/contract-upload/FileUploadArea.tsx
@@ -59,15 +59,15 @@ export function FileUploadArea({
         className={`
           p-10 border-2 border-dashed rounded-lg text-center
           transition-colors duration-200 ease-in-out
-          ${isDragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-white'}
-          ${error ? 'border-red-300' : ''}
-          ${isUploading ? 'cursor-wait opacity-75' : 'cursor-pointer hover:border-gray-400'}
+          ${isDragActive ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20' : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800'}
+          ${error ? 'border-red-300 dark:border-red-500' : ''}
+          ${isUploading ? 'cursor-wait opacity-75' : 'cursor-pointer hover:border-gray-400 dark:hover:border-gray-500'}
         `}
       >
         <input {...getInputProps()} disabled={isUploading} />
         
         {isUploading ? (
-          <div className="text-gray-500">
+          <div className="text-gray-500 dark:text-gray-400">
             <svg
               className="animate-spin h-6 w-6 mx-auto mb-2"
               xmlns="http://www.w3.org/2000/svg"
@@ -91,7 +91,7 @@ export function FileUploadArea({
             Processing file...
           </div>
         ) : file ? (
-          <div className="text-gray-500">
+          <div className="text-gray-500 dark:text-gray-400">
             <svg
               className="h-6 w-6 mx-auto mb-2"
               fill="none"
@@ -108,7 +108,7 @@ export function FileUploadArea({
             {file.name}
           </div>
         ) : (
-          <div className="text-gray-500">
+          <div className="text-gray-500 dark:text-gray-400">
             <svg
               className="h-6 w-6 mx-auto mb-2"
               fill="none"
@@ -127,14 +127,14 @@ export function FileUploadArea({
             ) : (
               'Drag & drop your contract, or click to select'
             )}
-            <p className="text-sm text-gray-400 mt-2">Supports PDF and DOCX files up to 10MB</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">Supports PDF and DOCX files up to 10MB</p>
           </div>
         )}
       </div>
 
       {/* Processing status display */}
       {processingStatus && (
-        <div className="text-sm text-gray-600 text-center animate-fade-in">
+        <div className="text-sm text-gray-600 dark:text-gray-300 text-center animate-fade-in">
           <span className="inline-block mr-2">
             <svg 
               className="w-4 h-4 inline-block animate-pulse" 

--- a/components/error/ErrorDisplay.tsx
+++ b/components/error/ErrorDisplay.tsx
@@ -8,8 +8,9 @@ interface ErrorDisplayProps {
 export function ErrorDisplay({ error }: ErrorDisplayProps) {
   return (
     <div className={`mt-4 p-4 rounded-lg text-center flex items-center justify-center gap-2
-      ${error.type === 'error' ? 'bg-red-50 border border-red-200 text-red-600' : 
-                               'bg-yellow-50 border border-yellow-200 text-yellow-600'}`}>
+      ${error.type === 'error' ? 
+        'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400' : 
+        'bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 text-yellow-600 dark:text-yellow-400'}`}>
       {error.type === 'error' ? 
         <AlertTriangle className="w-5 h-5" /> : 
         <Clock className="w-5 h-5" />}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,17 +3,35 @@ import { Button } from '@/components/ui/button'
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 py-12 px-4">
+    <footer className="bg-gray-100 dark:bg-gray-800 py-12 px-4">
       <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center">
         <div className="mb-8 md:mb-0">
-          <Button size="lg" className="bg-green-500 hover:bg-green-600 text-white">
+          <Button size="lg" className="bg-green-500 hover:bg-green-600 text-white dark:bg-green-600 dark:hover:bg-green-700">
             Get Started
           </Button>
         </div>
-        <div className="space-x-4 text-sm text-gray-600">
-          <Link href="/privacy" prefetch={false} className="hover:text-gray-800">Privacy Policy</Link>
-          <Link href="/terms" prefetch={false} className="hover:text-gray-800">Terms of Service</Link>
-          <Link href="/contact" prefetch={false} className="hover:text-gray-800">Contact</Link>
+        <div className="space-x-4 text-sm text-gray-600 dark:text-gray-400">
+          <Link 
+            href="/privacy" 
+            prefetch={false} 
+            className="hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            Privacy Policy
+          </Link>
+          <Link 
+            href="/terms" 
+            prefetch={false} 
+            className="hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            Terms of Service
+          </Link>
+          <Link 
+            href="/contact" 
+            prefetch={false} 
+            className="hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            Contact
+          </Link>
         </div>
       </div>
     </footer>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,14 +4,14 @@ export default function Header() {
   return (
     <header className="py-6 px-4 md:px-8">
       <nav className="max-w-7xl mx-auto flex justify-between items-center">
-        <Link href="/" className="text-2xl font-bold text-gray-800">
+        <Link href="/" className="text-2xl font-bold text-gray-800 dark:text-gray-100">
           dontSign.ai
         </Link>
         <div className="space-x-4">
-          <Link href="#how-it-works" className="text-gray-600 hover:text-gray-800">
+          <Link href="#how-it-works" className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100">
             How it Works
           </Link>
-          <Link href="#key-features" className="text-gray-600 hover:text-gray-800">
+          <Link href="#key-features" className="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100">
             Key Features
           </Link>
         </div>
@@ -19,4 +19,3 @@ export default function Header() {
     </header>
   )
 }
-

--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -20,7 +20,7 @@ export default function Hero() {
   const [progress, setProgress] = useState(0);
   const [stage, setStage] = useState<'preprocessing' | 'analyzing' | 'complete'>('preprocessing');
   const [processingStatus, setProcessingStatus] = useState<string>('');
-  
+
   const handleFileSelect = async (selectedFile: File | null) => {
     if (!selectedFile) {
       setError({
@@ -209,12 +209,12 @@ export default function Hero() {
   };
 
   return (
-    <section className="py-20 px-4 bg-gradient-to-br from-blue-50 via-white to-blue-50">
+    <section className="py-20 px-4 bg-gradient-to-br from-blue-50 via-white to-blue-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <div className="max-w-5xl mx-auto">
-        <h1 className="text-5xl font-bold mb-6 tracking-tight text-gray-900 text-center">
+        <h1 className="text-5xl font-bold mb-6 tracking-tight text-gray-900 dark:text-white text-center">
           Don't Sign Until<br />You're Sure
         </h1>
-        <p className="text-xl text-gray-600 mb-12 max-w-2xl mx-auto text-center">
+        <p className="text-xl text-gray-600 dark:text-gray-300 mb-12 max-w-2xl mx-auto text-center">
           Upload your contract, let AI highlight the risks and key terms.
         </p>
 

--- a/components/how-it-works.tsx
+++ b/components/how-it-works.tsx
@@ -20,19 +20,19 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section id="how-it-works" className="py-20 px-4 bg-white">
+    <section id="how-it-works" className="py-20 px-4 bg-white dark:bg-gray-800">
       <div className="max-w-7xl mx-auto">
-        <h2 className="text-4xl font-bold text-center mb-16">How it Works</h2>
+        <h2 className="text-4xl font-bold text-center mb-16 text-gray-900 dark:text-white">How it Works</h2>
         <div className="grid md:grid-cols-3 gap-12">
           {steps.map((step, index) => (
             <div key={index} className="relative">
-              <div className="text-8xl font-bold text-gray-100 absolute -top-10 -left-6">
+              <div className="text-8xl font-bold text-gray-100 dark:text-gray-700 absolute -top-10 -left-6">
                 {index + 1}
               </div>
               <div className="relative">
-                <step.icon className="w-12 h-12 mb-4 text-blue-500" />
-                <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
-                <p className="text-gray-600">{step.description}</p>
+                <step.icon className="w-12 h-12 mb-4 text-blue-500 dark:text-blue-400" />
+                <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-white">{step.title}</h3>
+                <p className="text-gray-600 dark:text-gray-300">{step.description}</p>
               </div>
             </div>
           ))}
@@ -41,4 +41,3 @@ export default function HowItWorks() {
     </section>
   )
 }
-

--- a/components/key-features.tsx
+++ b/components/key-features.tsx
@@ -13,22 +13,22 @@ const features = [
   },
   {
     icon: FileText,
-    title: "Concise Summaries",
+    title: "Clear Summaries",
     description: "Summarizes complex documents into clear insights, giving you a snapshot of what's important."
   }
 ]
 
 export default function KeyFeatures() {
   return (
-    <section id="key-features" className="py-20 px-4">
+    <section id="key-features" className="py-20 px-4 bg-white dark:bg-gray-800">
       <div className="max-w-7xl mx-auto">
-        <h2 className="text-4xl font-bold text-center mb-16">Key Features</h2>
+        <h2 className="text-4xl font-bold text-center mb-16 text-gray-900 dark:text-white">Key Features</h2>
         <div className="grid md:grid-cols-3 gap-12">
           {features.map((feature, index) => (
             <div key={index} className="text-center">
-              <feature.icon className="w-12 h-12 mx-auto mb-4 text-blue-500" />
-              <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
-              <p className="text-gray-600">{feature.description}</p>
+              <feature.icon className="w-12 h-12 mx-auto mb-4 text-blue-500 dark:text-blue-400" />
+              <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-white">{feature.title}</h3>
+              <p className="text-gray-600 dark:text-gray-300">{feature.description}</p>
             </div>
           ))}
         </div>
@@ -36,4 +36,3 @@ export default function KeyFeatures() {
     </section>
   )
 }
-

--- a/components/theme/theme-provider.tsx
+++ b/components/theme/theme-provider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+type ThemeProviderProps = Parameters<typeof NextThemesProvider>[0]
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/components/theme/theme-toggle.tsx
+++ b/components/theme/theme-toggle.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" className="fixed top-4 right-4">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+}

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -9,12 +9,12 @@ export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value = 0, indicatorColor = 'bg-blue-600', ...props }, ref) => {
+  ({ className, value = 0, indicatorColor = 'bg-blue-600 dark:bg-blue-500', ...props }, ref) => {
     return (
       <div
         ref={ref}
         className={cn(
-          "relative h-4 w-full overflow-hidden rounded-full bg-gray-100",
+          "relative h-4 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700",
           className
         )}
         {...props}

--- a/docs/dark-mode.md
+++ b/docs/dark-mode.md
@@ -1,0 +1,170 @@
+# Dark Mode Implementation
+
+This document outlines the dark mode implementation in the DontSign application. The implementation uses `next-themes` for theme management and follows Tailwind's dark mode conventions.
+
+## New Components Added
+
+### Theme Provider (`components/theme/theme-provider.tsx`)
+- Wraps the application with Next.js theme context
+- Handles system theme detection and user preferences
+- Persists theme selection
+
+### Theme Toggle (`components/theme/theme-toggle.tsx`)
+- Adds a sun/moon icon button in the top-right corner
+- Provides a dropdown menu for theme selection (Light/Dark/System)
+- Uses shadcn/ui components for consistent styling
+
+## Component Updates
+
+### Header (`components/header.tsx`)
+- Added dark mode text colors
+- Updated hover states for navigation links
+- Dark mode colors: `text-gray-100` for logo, `text-gray-300` for links
+
+### Hero (`components/hero/Hero.tsx`)
+- Updated background gradient for dark mode
+- Adjusted text colors for better contrast
+- Modified heading and description colors
+
+### FileUploadArea (`components/contract-upload/FileUploadArea.tsx`)
+- Added dark mode styles for the upload area
+- Updated border colors and hover states
+- Improved text contrast in dark mode
+- Modified icon colors and processing states
+
+### HowItWorks (`components/how-it-works.tsx`)
+- Added dark background: `bg-gray-800`
+- Updated text colors for better readability
+- Modified step number colors: `text-gray-700`
+- Adjusted icon colors: `text-blue-400`
+- Enhanced heading and description contrast
+
+### Footer (`components/footer.tsx`)
+- Added dark background: `bg-gray-800`
+- Updated link colors and hover states
+- Modified "Get Started" button for dark mode
+- Improved text contrast: `text-gray-400` base color
+
+## Configuration Changes
+
+### Tailwind Configuration
+- Added dark mode support using `class` strategy
+- Added semantic color variables
+- Configured animation utilities
+
+### Global Styles
+- Added CSS variables for theme colors
+- Defined semantic color tokens
+- Added dark mode variants
+
+## Dependencies Added
+```json
+{
+  "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "next-themes": "^0.2.1",
+    "class-variance-authority": "^0.7.0"
+  }
+}
+```
+
+## Testing Instructions
+
+1. Theme Toggle:
+   - Click the sun/moon icon in top-right corner
+   - Try all three options: Light, Dark, System
+   - Verify theme persistence after page reload
+
+2. Visual Testing:
+   - Check all components in both themes
+   - Verify text contrast and readability
+   - Test hover states and animations
+   - Ensure no color clashes
+
+3. Functionality Testing:
+   - Verify file upload works in both themes
+   - Check analysis process visualization
+   - Test error states and messages
+   - Verify all interactive elements
+
+## Developer Notes
+
+### Adding Dark Mode to New Components
+When creating new components, follow these guidelines for dark mode support:
+
+1. Use semantic color classes:
+```jsx
+// Good
+className="text-gray-900 dark:text-white"
+
+// Avoid
+className="text-black dark:text-[#ffffff]"
+```
+
+2. Use Tailwind's dark mode modifier:
+```jsx
+className="bg-white dark:bg-gray-800"
+```
+
+3. Consider both themes when adding interactive states:
+```jsx
+className="hover:bg-gray-100 dark:hover:bg-gray-700"
+```
+
+4. Test contrast ratios in both themes
+
+### Common Color Combinations
+```jsx
+// Backgrounds
+const backgrounds = {
+  primary: "bg-white dark:bg-gray-800",
+  secondary: "bg-gray-50 dark:bg-gray-900",
+  accent: "bg-blue-500 dark:bg-blue-600"
+}
+
+// Text
+const text = {
+  primary: "text-gray-900 dark:text-white",
+  secondary: "text-gray-600 dark:text-gray-300",
+  muted: "text-gray-500 dark:text-gray-400"
+}
+
+// Borders
+const borders = {
+  default: "border-gray-200 dark:border-gray-700",
+  focus: "focus:border-blue-500 dark:focus:border-blue-400"
+}
+```
+
+## Accessibility Considerations
+
+- Maintain WCAG 2.1 contrast ratios in both themes
+- Ensure focus states are visible in dark mode
+- Test with screen readers in both themes
+- Verify color-coding is not the only way to convey information
+
+## Future Improvements
+
+1. Add more granular theme customization
+2. Implement theme-specific animations
+3. Add high contrast mode
+4. Consider adding more color themes
+5. Improve system theme detection
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. Theme flicker on load:
+   - Ensure `suppressHydrationWarning` is set on html element
+   - Use `defaultTheme` prop in ThemeProvider
+
+2. Inconsistent colors:
+   - Check CSS variable definitions
+   - Verify Tailwind config
+   - Test in incognito mode
+
+3. Theme not persisting:
+   - Check localStorage access
+   - Verify ThemeProvider setup
+   - Clear browser cache

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+ 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "dontsign",
       "version": "1.1.0",
       "dependencies": {
+        "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-slot": "^1.0.2",
         "@sentry/nextjs": "^7.101.0",
-        "class-variance-authority": "^0.7.0",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "lucide-react": "^0.323.0",
         "next": "14.1.0",
+        "next-themes": "^0.2.1",
         "openai": "^4.26.0",
         "pdfjs-dist": "3.11.174",
         "react": "^18",
@@ -103,6 +105,40 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -422,6 +458,58 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
+      "integrity": "sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
@@ -432,6 +520,311 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
+      "integrity": "sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.4.tgz",
+      "integrity": "sha512-iXU1Ab5ecM+yEepGAWK8ZhMyKX4ubFdCNtol4sT9D0OVErG9PNElfx3TQhjw7n7BC5nFVz68/5//clWy+8TXzA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-menu": "2.1.4",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.4.tgz",
+      "integrity": "sha512-BnOgVoL6YYdHAG6DtXONaR29Eq4nvbi8rutrV/xlr3RQCMMb3yqP85Qiw/3NReozrSW+4dfLkK+rc1hb4wPU/A==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-roving-focus": "1.1.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
+      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.1.tgz",
+      "integrity": "sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -452,6 +845,107 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "24.0.0",
@@ -884,7 +1378,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1141,6 +1635,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -1831,6 +2336,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2790,6 +3300,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-symbol-description": {
@@ -3932,6 +4450,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4601,6 +5129,72 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
+      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5603,6 +6197,47 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@sentry/nextjs": "^7.101.0",
-    "class-variance-authority": "^0.7.0",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
     "lucide-react": "^0.323.0",
     "next": "14.1.0",
+    "next-themes": "^0.2.1",
     "openai": "^4.26.0",
     "pdfjs-dist": "3.11.174",
     "react": "^18",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,80 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'fade-up': {
+          '0%': {
+            opacity: '0',
+            transform: 'translateY(10px)'
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'translateY(0)'
+          },
+        },
+        'fade-down': {
+          '0%': {
+            opacity: '0',
+            transform: 'translateY(-10px)'
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'translateY(0)'
+          },
+        },
+      },
+      animation: {
+        'fade-up': 'fade-up 0.5s ease-out',
+        'fade-down': 'fade-down 0.5s ease-out',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+}


### PR DESCRIPTION
This PR adds dark mode support to the application. Changes include:

1. Added ThemeProvider from next-themes
2. Created ThemeToggle component with light/dark/system options
3. Updated root layout to support themes
4. Added theme toggle button to main page

The implementation uses next-themes library which is compatible with Next.js 14 and works well with Tailwind CSS. The theme toggle is positioned in the top-right corner and includes a smooth transition animation.

Testing Instructions:
1. Click the sun/moon icon in the top-right corner
2. Try switching between light, dark, and system themes
3. Verify that all components render correctly in both themes
4. Check that the theme preference persists after page refresh

Note: This PR is based on the `feature/analysis-progress-bar` branch and includes all its changes.

Dependencies to install:
```bash
npm install next-themes
```