### PR TITLE
fix: Fix TypeScript type inference in useAnalysisLog

### DIFF
--- a/components/analysis-log/useAnalysisLog.ts
+++ b/components/analysis-log/useAnalysisLog.ts
@@ -25,7 +25,7 @@ export const useAnalysisLog = (): AnalysisLogState => {
     setEntries(current => {
       // If there's an active entry, mark it as complete
       const updated = current.map(e => 
-        e.status === 'active' ? { ...e, status: 'complete' } : e
+        e.status === 'active' ? { ...e, status: 'complete' as const } : e
       );
       return [...updated, entry];
     });
@@ -36,7 +36,7 @@ export const useAnalysisLog = (): AnalysisLogState => {
       if (current.length === 0) return current;
       
       return current.map((entry, index) => 
-        index === current.length - 1 ? { ...entry, status } : entry
+        index === current.length - 1 ? { ...entry, status: status as LogEntry['status'] } : entry
       );
     });
   }, []);


### PR DESCRIPTION
This PR fixes a TypeScript compilation error in the `useAnalysisLog` hook.

### Changes Made
- Added explicit type assertions for status values to preserve the union type
- Used `as const` to preserve literal types
- Fixed map function return types

### Testing
- Verified TypeScript compilation passes
- Functionality remains unchanged
- No regression in status handling

### Additional Notes
This is a type-level fix only - no runtime behavior changes.