### PR TITLE
fix: Fix duplicate keys in analysis log entries

### DIFF
--- a/components/analysis-log/useAnalysisLog.ts
+++ b/components/analysis-log/useAnalysisLog.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { LogEntry } from './AnalysisLog';
 
 export interface AnalysisLogState {
@@ -9,14 +9,21 @@ export interface AnalysisLogState {
 }
 
 /**
- * Hook to manage analysis log entries
+ * Hook to manage analysis log entries with guaranteed unique IDs
  */
 export const useAnalysisLog = (): AnalysisLogState => {
   const [entries, setEntries] = useState<LogEntry[]>([]);
+  const idCounter = useRef(0);
+
+  // Generate a guaranteed unique ID by combining timestamp and counter
+  const generateUniqueId = () => {
+    idCounter.current += 1;
+    return `${Date.now()}-${idCounter.current}`;
+  };
 
   const addEntry = useCallback((message: string, status: LogEntry['status'] = 'active') => {
     const entry: LogEntry = {
-      id: Date.now().toString(),
+      id: generateUniqueId(),
       message,
       status,
       timestamp: new Date()
@@ -43,6 +50,8 @@ export const useAnalysisLog = (): AnalysisLogState => {
 
   const clearEntries = useCallback(() => {
     setEntries([]);
+    // Reset the counter when clearing entries
+    idCounter.current = 0;
   }, []);
 
   return {


### PR DESCRIPTION
This PR fixes the React warning about duplicate keys in the analysis log component by implementing a more robust key generation system.

### Problem
The current implementation uses `Date.now().toString()` for generating entry IDs, which can create duplicate keys when entries are created in rapid succession within the same millisecond.

### Solution
- Added a counter-based ID generation system using `useRef`
- Combined timestamp with counter for guaranteed uniqueness (format: `${timestamp}-${counter}`)
- Added counter reset when clearing entries
- Maintained existing TypeScript type safety

### Changes
- Added `idCounter` useRef to track entry counts
- Created `generateUniqueId` function to combine timestamp and counter
- Reset counter in `clearEntries` function
- Updated JSDoc comments for clarity

### Testing
- Verified that React key warnings are resolved
- Ensured no duplicate keys during rapid entry creation
- Confirmed counter resets properly on clear
- Maintained existing functionality

### Impact
This change has no impact on the user experience but improves React's internal rendering efficiency and removes console warnings.