### PR TITLE
fix: Add border color to Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,9 @@ module.exports = {
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
     extend: {
+      colors: {
+        border: "hsl(var(--border))"
+      },
       keyframes: {
         fadeIn: {
           '0%': { opacity: '0', transform: 'translateY(10px)' },


### PR DESCRIPTION
- Add border color definition to theme.extend.colors
- Keep all existing configurations intact
- Fix border-border class error