### PR TITLE
Fix/persist analysis state (#93)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -18,16 +18,16 @@ export default function Error({ error, reset }: ErrorProps) {
 
   return (
     <div className="flex min-h-[50vh] flex-col items-center justify-center p-4 text-center">
-      <h2 className="text-2xl font-bold mb-4">Something went wrong!</h2>
-      <p className="text-gray-600 mb-4">We've been notified and are working to fix the issue.</p>
+      <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Something went wrong!</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-4">We've been notified and are working to fix the issue.</p>
       {process.env.NODE_ENV === 'development' && (
-        <pre className="text-left bg-gray-100 p-4 rounded-md overflow-auto max-w-full">
+        <pre className="text-left bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-4 rounded-md overflow-auto max-w-full border border-gray-200 dark:border-gray-700">
           {error.message}
         </pre>
       )}
       <button
         onClick={reset}
-        className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors"
+        className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors dark:bg-blue-600 dark:hover:bg-blue-700"
       >
         Try Again
       </button>

--- a/components/hero/AnalysisSection.tsx
+++ b/components/hero/AnalysisSection.tsx
@@ -6,7 +6,7 @@ import { ErrorDisplay } from '../error/ErrorDisplay';
 import { AnalysisResults } from '../analysis-results/AnalysisResults';
 import { AnalysisHistory } from '../analysis-history/AnalysisHistory';
 import { Button } from '@/components/ui/button';
-import { History, FileText } from 'lucide-react';
+import { History } from 'lucide-react';
 import type { StoredAnalysis } from '@/lib/storage';
 import type { AnalysisResult } from '@/types/analysis';
 import type { AnalysisStage } from './hooks/useContractAnalysis';
@@ -49,7 +49,6 @@ export const AnalysisSection = ({
   showResults,
   currentStoredAnalysis,
   hasStoredAnalyses,
-  showAnalysisButton,
   onFileSelect,
   onAnalyze,
   onShowResults,
@@ -74,32 +73,19 @@ export const AnalysisSection = ({
             </p>
           </div>
 
-          {/* Analysis Controls */}
-          {(hasStoredAnalyses || showAnalysisButton) && (
-            <div className="mb-8 flex justify-center gap-3">
-              {showAnalysisButton && (
+          {/* Analysis History */}
+          {hasStoredAnalyses && (
+            <div className="mb-8 flex justify-center">
+              <AnalysisHistory onSelect={onSelectStoredAnalysis}>
                 <Button
-                  variant="default"
+                  variant="outline"
                   size="lg"
-                  className="gap-2 bg-gray-900 hover:bg-gray-800 text-white dark:bg-gray-800 dark:hover:bg-gray-700"
-                  onClick={() => onShowResults(true)}
+                  className="gap-2 border-gray-300 dark:border-gray-700"
                 >
-                  <FileText className="w-5 h-5" />
-                  View Latest Analysis
+                  <History className="w-5 h-5" />
+                  Previous Analyses
                 </Button>
-              )}
-              {hasStoredAnalyses && (
-                <AnalysisHistory onSelect={onSelectStoredAnalysis}>
-                  <Button
-                    variant="outline"
-                    size="lg"
-                    className="gap-2 border-gray-300 dark:border-gray-700"
-                  >
-                    <History className="w-5 h-5" />
-                    Previous Analyses
-                  </Button>
-                </AnalysisHistory>
-              )}
+              </AnalysisHistory>
             </div>
           )}
 


### PR DESCRIPTION
* fix: restore analysis state from localStorage on component mount

* fix: restore analysis state from localStorage on component mount

* fix: complete Hero.tsx component update

* fix: add setAnalysisState function to useContractAnalysis hook

* fix: add dark mode support to error page

* fix: add dark mode support to error page

* fix: prevent infinite state update loop by making setAnalysisState accept partial updates

* fix: update Hero component to avoid state update loops

* fix: don't auto-show analysis results on page load

* fix: reset analysis state when starting new analysis

* fix: prevent old analysis restoration during new analysis

* fix: add resetAnalysisState function and improve state management

* fix: reset states on file selection, not just on analysis start

* refactor: remove redundant View Latest Analysis button