### PR TITLE
Standardize error type naming

### DIFF
--- a/app/actions/detectDocumentType.ts
+++ b/app/actions/detectDocumentType.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { openAIService } from '@/lib/services/openai/openai-service';
+import { promptManager } from '@/lib/services/prompts';
+import { ContractAnalysisError } from '@/lib/errors';
+import type { DocumentTypeResponse } from '@/lib/services/prompts/types';
+
+export async function detectDocumentType(text: string): Promise<DocumentTypeResponse> {
+  // Take a sample from the start of the document for classification
+  const sampleText = text.slice(0, 3000);
+
+  const [typePrompt, config] = await Promise.all([
+    promptManager.getPrompt('document-type', { text: sampleText }),
+    promptManager.getModelConfig('documentType')
+  ]);
+
+  const response = await openAIService.createChatCompletion({
+    model: config.model,
+    temperature: config.temperature,
+    max_tokens: config.max_tokens,
+    response_format: config.response_format,
+    messages: [
+      { role: "user", content: typePrompt }
+    ],
+    stream: false
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new ContractAnalysisError('Document type detection failed', 'API_ERROR');
+  }
+
+  try {
+    const result = JSON.parse(content) as DocumentTypeResponse;
+    
+    // Validate the response structure
+    if (
+      typeof result.isLegalDocument !== 'boolean' ||
+      typeof result.documentType !== 'string' ||
+      typeof result.confidence !== 'number' ||
+      typeof result.explanation !== 'string' ||
+      !['proceed_with_analysis', 'stop_analysis'].includes(result.recommendedAction)
+    ) {
+      throw new Error('Invalid response structure');
+    }
+
+    return result;
+  } catch (error) {
+    throw new ContractAnalysisError(
+      'Failed to parse document type detection response',
+      'API_ERROR'
+    );
+  }
+}

--- a/components/contract-analyzer/ContractAnalyzer.tsx
+++ b/components/contract-analyzer/ContractAnalyzer.tsx
@@ -67,7 +67,7 @@ export const ContractAnalyzer = () => {
         />
 
         {/* Analysis Progress */}
-        {isAnalyzing && (
+        {isAnalyzing && !error && (
           <div className="w-full max-w-md mx-auto">
             <AnalysisProgress
               sectionsAnalyzed={sectionsAnalyzed}
@@ -80,17 +80,24 @@ export const ContractAnalyzer = () => {
           </div>
         )}
 
-        {/* Error Display */}
-        {error && <ErrorDisplay error={error} />}
-
-        {/* Analysis Results */}
-        {results.isVisible && analysis && (
-          <AnalysisResults analysis={analysis} onClose={() => results.hide()} />
-        )}
+        {/* Analysis Results or Error Display */}
+        {error ? (
+          <AnalysisResults 
+            analysis={null} 
+            error={error} 
+            onClose={() => actions.handleClearError()} 
+          />
+        ) : results.isVisible && analysis ? (
+          <AnalysisResults 
+            analysis={analysis} 
+            error={null}
+            onClose={() => results.hide()} 
+          />
+        ) : null}
       </div>
 
       {/* Analysis Log */}
-      {log.entries.length > 0 && (
+      {!error && log.entries.length > 0 && (
         <AnalysisLog
           entries={log.entries}
           isVisible={log.isVisible}

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -38,7 +38,6 @@ export const AnalysisResults = ({
   // If it's an error, we want a smaller modal that fits the content
   // If it's analysis results, we want the full-size modal
   const modalSize = error ? 'fit-content' : 'w-full max-w-4xl max-h-[90vh]';
-  const padding = error ? 'p-0' : 'p-6'; // Remove padding for error display as it has its own padding
 
   return (
     <div 
@@ -50,7 +49,7 @@ export const AnalysisResults = ({
         onClick={e => e.stopPropagation()}
       >
         {/* Close button */}
-        <div className="absolute right-2 top-2 z-10">
+        <div className="absolute right-3 top-3 z-10">
           <Button
             variant="ghost"
             size="icon"
@@ -64,12 +63,12 @@ export const AnalysisResults = ({
 
         {error ? (
           // Error display - no ScrollArea needed
-          <div className="pt-2">
+          <div className="p-6 pt-12">
             <ErrorDisplay error={error} />
           </div>
         ) : analysis ? (
           // Analysis results - with ScrollArea
-          <ScrollArea className={`h-[80vh] touch-auto ${padding}`}>
+          <ScrollArea className="h-[80vh] p-6 touch-auto">
             <div className="space-y-8">
               {/* What is this contract? */}
               <section className="mb-8">

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -53,7 +53,7 @@ export const AnalysisResults = ({
           variant="ghost"
           size="icon"
           onClick={onClose}
-          className="absolute right-3 top-3 rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="absolute right-[2.3rem] top-[2.3rem] rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <X className="h-3 w-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
           <span className="sr-only">Close</span>
@@ -61,7 +61,7 @@ export const AnalysisResults = ({
 
         {error ? (
           // Error display - no ScrollArea needed
-          <div className="p-8">
+          <div className="p-[2.3rem]">
             <ErrorDisplay error={error} />
           </div>
         ) : analysis ? (

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -49,21 +49,19 @@ export const AnalysisResults = ({
         onClick={e => e.stopPropagation()}
       >
         {/* Close button */}
-        <div className="absolute right-12 top-12 z-10">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onClose}
-            className="rounded-full h-8 w-8 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <X className="h-4 w-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
-            <span className="sr-only">Close</span>
-          </Button>
-        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="absolute right-3 top-3 rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <X className="h-3 w-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
+          <span className="sr-only">Close</span>
+        </Button>
 
         {error ? (
           // Error display - no ScrollArea needed
-          <div className="p-12">
+          <div className="p-8">
             <ErrorDisplay error={error} />
           </div>
         ) : analysis ? (

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -53,7 +53,7 @@ export const AnalysisResults = ({
           variant="ghost"
           size="icon"
           onClick={onClose}
-          className="absolute right-[2.3rem] top-[2.3rem] rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 z-50"
+          className="absolute right-3 top-3 rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <X className="h-3 w-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
           <span className="sr-only">Close</span>
@@ -66,61 +66,59 @@ export const AnalysisResults = ({
           </div>
         ) : analysis ? (
           // Analysis results - with ScrollArea
-          <div className="relative">
-            <ScrollArea className="h-[80vh] touch-auto">
-              <div className="p-[2.3rem] space-y-8">
-                {/* What is this contract? */}
-                <section className="mb-8">
-                  <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
-                  <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
-                    {analysis.summary}
+          <ScrollArea className="h-[80vh] p-6 touch-auto">
+            <div className="space-y-8">
+              {/* What is this contract? */}
+              <section className="mb-8">
+                <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
+                <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
+                  {analysis.summary}
+                </p>
+              </section>
+
+              {/* Potential Risks */}
+              <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
+                <ul className="list-disc pl-5 space-y-2">
+                  {analysis.potentialRisks.map((risk, index) => (
+                    <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
+                  ))}
+                </ul>
+              </section>
+
+              {/* Important Clauses */}
+              <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
+                <ul className="list-disc pl-5 space-y-2">
+                  {analysis.importantClauses.map((clause, index) => (
+                    <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
+                  ))}
+                </ul>
+              </section>
+
+              {/* Recommendations */}
+              {analysis.recommendations && analysis.recommendations.length > 0 && (
+                <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
+                  <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
+                  <ul className="list-disc pl-5 space-y-2">
+                    {analysis.recommendations.map((rec, index) => (
+                      <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {/* Analysis Info */}
+              {analysis.metadata && (
+                <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
+                    {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
                   </p>
                 </section>
-
-                {/* Potential Risks */}
-                <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
-                  <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
-                  <ul className="list-disc pl-5 space-y-2">
-                    {analysis.potentialRisks.map((risk, index) => (
-                      <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
-                    ))}
-                  </ul>
-                </section>
-
-                {/* Important Clauses */}
-                <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
-                  <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
-                  <ul className="list-disc pl-5 space-y-2">
-                    {analysis.importantClauses.map((clause, index) => (
-                      <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
-                    ))}
-                  </ul>
-                </section>
-
-                {/* Recommendations */}
-                {analysis.recommendations && analysis.recommendations.length > 0 && (
-                  <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
-                    <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
-                    <ul className="list-disc pl-5 space-y-2">
-                      {analysis.recommendations.map((rec, index) => (
-                        <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
-                      ))}
-                    </ul>
-                  </section>
-                )}
-
-                {/* Analysis Info */}
-                {analysis.metadata && (
-                  <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
-                      {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
-                    </p>
-                  </section>
-                )}
-              </div>
-            </ScrollArea>
-          </div>
+              )}
+            </div>
+          </ScrollArea>
         ) : null}
       </Card>
     </div>

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -35,32 +35,41 @@ export const AnalysisResults = ({
     };
   }, []);
 
+  // If it's an error, we want a smaller modal that fits the content
+  // If it's analysis results, we want the full-size modal
+  const modalSize = error ? 'fit-content' : 'w-full max-w-4xl max-h-[90vh]';
+  const padding = error ? 'p-0' : 'p-6'; // Remove padding for error display as it has its own padding
+
   return (
     <div 
       className="fixed inset-0 bg-black bg-opacity-50 dark:bg-opacity-70 flex items-center justify-center p-4 z-50 overflow-hidden touch-none"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <Card 
-        className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-gray-800 shadow-xl relative overflow-hidden"
+        className={`${modalSize} bg-white dark:bg-gray-800 shadow-xl relative overflow-hidden`}
         onClick={e => e.stopPropagation()}
       >
         {/* Close button */}
-        <div className="absolute right-4 top-4 z-10">
+        <div className="absolute right-2 top-2 z-10">
           <Button
             variant="ghost"
             size="icon"
             onClick={onClose}
-            className="rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="rounded-full h-8 w-8 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            <X className="h-6 w-6 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
+            <X className="h-4 w-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
             <span className="sr-only">Close</span>
           </Button>
         </div>
 
-        <ScrollArea className="h-[80vh] p-6 touch-auto">
-          {error ? (
+        {error ? (
+          // Error display - no ScrollArea needed
+          <div className="pt-2">
             <ErrorDisplay error={error} />
-          ) : analysis ? (
+          </div>
+        ) : analysis ? (
+          // Analysis results - with ScrollArea
+          <ScrollArea className={`h-[80vh] touch-auto ${padding}`}>
             <div className="space-y-8">
               {/* What is this contract? */}
               <section className="mb-8">
@@ -112,8 +121,8 @@ export const AnalysisResults = ({
                 </section>
               )}
             </div>
-          ) : null}
-        </ScrollArea>
+          </ScrollArea>
+        ) : null}
       </Card>
     </div>
   );

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -48,12 +48,12 @@ export const AnalysisResults = ({
         className={`${modalSize} bg-white dark:bg-gray-800 shadow-xl relative overflow-hidden`}
         onClick={e => e.stopPropagation()}
       >
-        {/* Close button */}
+        {/* Close button - Always on top with z-index */}
         <Button
           variant="ghost"
           size="icon"
           onClick={onClose}
-          className="absolute right-3 top-3 rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="absolute right-3 top-3 rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 z-50"
         >
           <X className="h-3 w-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
           <span className="sr-only">Close</span>
@@ -66,7 +66,7 @@ export const AnalysisResults = ({
           </div>
         ) : analysis ? (
           // Analysis results - with ScrollArea
-          <ScrollArea className="h-[80vh] p-6 touch-auto">
+          <ScrollArea className="h-[80vh] p-6 touch-auto relative z-0">
             <div className="space-y-8">
               {/* What is this contract? */}
               <section className="mb-8">

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -53,7 +53,7 @@ export const AnalysisResults = ({
           variant="ghost"
           size="icon"
           onClick={onClose}
-          className="absolute right-[2.3rem] top-[2.3rem] rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="absolute right-[2.3rem] top-[2.3rem] rounded-full h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 z-50"
         >
           <X className="h-3 w-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" />
           <span className="sr-only">Close</span>
@@ -66,59 +66,61 @@ export const AnalysisResults = ({
           </div>
         ) : analysis ? (
           // Analysis results - with ScrollArea
-          <ScrollArea className="h-[80vh] p-6 touch-auto">
-            <div className="space-y-8">
-              {/* What is this contract? */}
-              <section className="mb-8">
-                <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
-                <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
-                  {analysis.summary}
-                </p>
-              </section>
+          <div className="relative">
+            <ScrollArea className="h-[80vh] touch-auto">
+              <div className="p-[2.3rem] space-y-8">
+                {/* What is this contract? */}
+                <section className="mb-8">
+                  <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
+                  <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
+                    {analysis.summary}
+                  </p>
+                </section>
 
-              {/* Potential Risks */}
-              <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
-                <ul className="list-disc pl-5 space-y-2">
-                  {analysis.potentialRisks.map((risk, index) => (
-                    <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
-                  ))}
-                </ul>
-              </section>
-
-              {/* Important Clauses */}
-              <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
-                <ul className="list-disc pl-5 space-y-2">
-                  {analysis.importantClauses.map((clause, index) => (
-                    <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
-                  ))}
-                </ul>
-              </section>
-
-              {/* Recommendations */}
-              {analysis.recommendations && analysis.recommendations.length > 0 && (
-                <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
-                  <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
+                {/* Potential Risks */}
+                <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
+                  <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
                   <ul className="list-disc pl-5 space-y-2">
-                    {analysis.recommendations.map((rec, index) => (
-                      <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
+                    {analysis.potentialRisks.map((risk, index) => (
+                      <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
                     ))}
                   </ul>
                 </section>
-              )}
 
-              {/* Analysis Info */}
-              {analysis.metadata && (
-                <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
-                    {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
-                  </p>
+                {/* Important Clauses */}
+                <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
+                  <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
+                  <ul className="list-disc pl-5 space-y-2">
+                    {analysis.importantClauses.map((clause, index) => (
+                      <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
+                    ))}
+                  </ul>
                 </section>
-              )}
-            </div>
-          </ScrollArea>
+
+                {/* Recommendations */}
+                {analysis.recommendations && analysis.recommendations.length > 0 && (
+                  <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
+                    <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
+                    <ul className="list-disc pl-5 space-y-2">
+                      {analysis.recommendations.map((rec, index) => (
+                        <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {/* Analysis Info */}
+                {analysis.metadata && (
+                  <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
+                      {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
+                    </p>
+                  </section>
+                )}
+              </div>
+            </ScrollArea>
+          </div>
         ) : null}
       </Card>
     </div>

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -49,7 +49,7 @@ export const AnalysisResults = ({
         onClick={e => e.stopPropagation()}
       >
         {/* Close button */}
-        <div className="absolute right-3 top-3 z-10">
+        <div className="absolute right-12 top-12 z-10">
           <Button
             variant="ghost"
             size="icon"
@@ -63,7 +63,7 @@ export const AnalysisResults = ({
 
         {error ? (
           // Error display - no ScrollArea needed
-          <div className="p-6 pt-12">
+          <div className="p-12">
             <ErrorDisplay error={error} />
           </div>
         ) : analysis ? (

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -1,8 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
+import { ErrorDisplay } from '@/components/error/ErrorDisplay';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import type { AnalysisResult } from '../../types';
@@ -16,49 +15,6 @@ interface AnalysisResultsProps {
   onClose: () => void;
 }
 
-function EmptyDocumentError() {
-  return (
-    <div className="p-6 max-w-2xl mx-auto text-center">
-      <Alert variant="destructive" className="mb-4">
-        <AlertCircle className="h-4 w-4" />
-        <AlertTitle>Empty Document</AlertTitle>
-        <AlertDescription>
-          We couldn't detect any text in this document. Please make sure the document contains readable text and try again.
-        </AlertDescription>
-      </Alert>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
-        Common reasons for this:
-        <ul className="list-disc text-left mt-2 pl-4">
-          <li>The document is image-based (scanned) rather than text-based</li>
-          <li>The PDF is password protected</li>
-          <li>The file is corrupted or empty</li>
-        </ul>
-      </p>
-    </div>
-  );
-}
-
-function NonLegalDocumentError({ message }: { message: string }) {
-  return (
-    <div className="p-6 max-w-2xl mx-auto text-center">
-      <Alert variant="destructive" className="mb-4">
-        <AlertCircle className="h-4 w-4" />
-        <AlertTitle>Unsupported Document Type</AlertTitle>
-        <AlertDescription>{message}</AlertDescription>
-      </Alert>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
-        This tool is designed specifically for legal documents such as:
-        <ul className="list-disc text-left mt-2 pl-4">
-          <li>Contracts and Agreements</li>
-          <li>NDAs and Confidentiality Agreements</li>
-          <li>Terms of Service</li>
-          <li>Legal Policies and Procedures</li>
-        </ul>
-      </p>
-    </div>
-  );
-}
-
 export const AnalysisResults = ({
   analysis,
   error,
@@ -66,14 +22,12 @@ export const AnalysisResults = ({
 }: AnalysisResultsProps) => {
   // Lock body scroll when modal is open
   useEffect(() => {
-    // Save current scroll position
     const scrollPos = window.scrollY;
     document.body.style.position = 'fixed';
     document.body.style.top = `-${scrollPos}px`;
     document.body.style.width = '100%';
 
     return () => {
-      // Restore scroll position on unmount
       document.body.style.position = '';
       document.body.style.top = '';
       document.body.style.width = '';
@@ -105,17 +59,7 @@ export const AnalysisResults = ({
 
         <ScrollArea className="h-[80vh] p-6 touch-auto">
           {error ? (
-            error.type === 'INVALID_INPUT' ? (
-              <EmptyDocumentError />
-            ) : error.type === 'INVALID_DOCUMENT_TYPE' ? (
-              <NonLegalDocumentError message={error.message} />
-            ) : (
-              <Alert variant="destructive" className="mb-4">
-                <AlertCircle className="h-4 w-4" />
-                <AlertTitle>Error</AlertTitle>
-                <AlertDescription>{error.message}</AlertDescription>
-              </Alert>
-            )
+            <ErrorDisplay error={error} />
           ) : analysis ? (
             <div className="space-y-8">
               {/* What is this contract? */}

--- a/components/contract-analyzer/components/analysis/AnalysisResults.tsx
+++ b/components/contract-analyzer/components/analysis/AnalysisResults.tsx
@@ -1,17 +1,67 @@
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import type { AnalysisResult } from '../../types';
 
 interface AnalysisResultsProps {
-  analysis: AnalysisResult;
+  analysis: AnalysisResult | null;
+  error?: {
+    message: string;
+    type: string;
+  } | null;
   onClose: () => void;
+}
+
+function EmptyDocumentError() {
+  return (
+    <div className="p-6 max-w-2xl mx-auto text-center">
+      <Alert variant="destructive" className="mb-4">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Empty Document</AlertTitle>
+        <AlertDescription>
+          We couldn't detect any text in this document. Please make sure the document contains readable text and try again.
+        </AlertDescription>
+      </Alert>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
+        Common reasons for this:
+        <ul className="list-disc text-left mt-2 pl-4">
+          <li>The document is image-based (scanned) rather than text-based</li>
+          <li>The PDF is password protected</li>
+          <li>The file is corrupted or empty</li>
+        </ul>
+      </p>
+    </div>
+  );
+}
+
+function NonLegalDocumentError({ message }: { message: string }) {
+  return (
+    <div className="p-6 max-w-2xl mx-auto text-center">
+      <Alert variant="destructive" className="mb-4">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Unsupported Document Type</AlertTitle>
+        <AlertDescription>{message}</AlertDescription>
+      </Alert>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
+        This tool is designed specifically for legal documents such as:
+        <ul className="list-disc text-left mt-2 pl-4">
+          <li>Contracts and Agreements</li>
+          <li>NDAs and Confidentiality Agreements</li>
+          <li>Terms of Service</li>
+          <li>Legal Policies and Procedures</li>
+        </ul>
+      </p>
+    </div>
+  );
 }
 
 export const AnalysisResults = ({
   analysis,
+  error,
   onClose
 }: AnalysisResultsProps) => {
   // Lock body scroll when modal is open
@@ -54,57 +104,71 @@ export const AnalysisResults = ({
         </div>
 
         <ScrollArea className="h-[80vh] p-6 touch-auto">
-          <div className="space-y-8">
-            {/* What is this contract? */}
-            <section className="mb-8">
-              <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
-              <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
-                {analysis.summary}
-              </p>
-            </section>
+          {error ? (
+            error.type === 'INVALID_INPUT' ? (
+              <EmptyDocumentError />
+            ) : error.type === 'INVALID_DOCUMENT_TYPE' ? (
+              <NonLegalDocumentError message={error.message} />
+            ) : (
+              <Alert variant="destructive" className="mb-4">
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>{error.message}</AlertDescription>
+              </Alert>
+            )
+          ) : analysis ? (
+            <div className="space-y-8">
+              {/* What is this contract? */}
+              <section className="mb-8">
+                <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">What is this contract?</h2>
+                <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line text-lg">
+                  {analysis.summary}
+                </p>
+              </section>
 
-            {/* Potential Risks */}
-            <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
-              <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
-              <ul className="list-disc pl-5 space-y-2">
-                {analysis.potentialRisks.map((risk, index) => (
-                  <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
-                ))}
-              </ul>
-            </section>
-
-            {/* Important Clauses */}
-            <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
-              <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
-              <ul className="list-disc pl-5 space-y-2">
-                {analysis.importantClauses.map((clause, index) => (
-                  <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
-                ))}
-              </ul>
-            </section>
-
-            {/* Recommendations */}
-            {analysis.recommendations && analysis.recommendations.length > 0 && (
-              <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
+              {/* Potential Risks */}
+              <section className="bg-red-50 dark:bg-red-950/30 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4 text-red-700 dark:text-red-400">Potential Risks</h2>
                 <ul className="list-disc pl-5 space-y-2">
-                  {analysis.recommendations.map((rec, index) => (
-                    <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
+                  {analysis.potentialRisks.map((risk, index) => (
+                    <li key={index} className="text-gray-700 dark:text-gray-300">{risk}</li>
                   ))}
                 </ul>
               </section>
-            )}
 
-            {/* Analysis Info */}
-            {analysis.metadata && (
-              <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
-                  {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
-                </p>
+              {/* Important Clauses */}
+              <section className="bg-blue-50 dark:bg-blue-950/30 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4 text-blue-700 dark:text-blue-400">Key Dates & Requirements</h2>
+                <ul className="list-disc pl-5 space-y-2">
+                  {analysis.importantClauses.map((clause, index) => (
+                    <li key={index} className="text-gray-700 dark:text-gray-300">{clause}</li>
+                  ))}
+                </ul>
               </section>
-            )}
-          </div>
+
+              {/* Recommendations */}
+              {analysis.recommendations && analysis.recommendations.length > 0 && (
+                <section className="bg-green-50 dark:bg-green-950/30 p-6 rounded-lg">
+                  <h2 className="text-2xl font-bold mb-4 text-green-700 dark:text-green-400">Next Steps</h2>
+                  <ul className="list-disc pl-5 space-y-2">
+                    {analysis.recommendations.map((rec, index) => (
+                      <li key={index} className="text-gray-700 dark:text-gray-300">{rec}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {/* Analysis Info */}
+              {analysis.metadata && (
+                <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Analysis completed at {new Date(analysis.metadata.analyzedAt).toLocaleString()}
+                    {analysis.metadata.sectionsAnalyzed && ` • ${analysis.metadata.sectionsAnalyzed} sections analyzed`}
+                  </p>
+                </section>
+              )}
+            </div>
+          ) : null}
         </ScrollArea>
       </Card>
     </div>

--- a/components/contract-analyzer/components/error-alert.tsx
+++ b/components/contract-analyzer/components/error-alert.tsx
@@ -1,11 +1,11 @@
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import type { ErrorType } from '@/lib/errors';
+import type { ErrorCode } from '@/lib/errors';
 
 interface ErrorAlertProps {
   error: {
     message: string;
-    type: ErrorType;
+    type: ErrorCode;
   };
 }
 

--- a/components/contract-analyzer/components/error-alert.tsx
+++ b/components/contract-analyzer/components/error-alert.tsx
@@ -1,11 +1,11 @@
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import type { ErrorType } from '@/lib/errors';
+import type { ErrorCode } from '@/lib/errors';
 
 interface ErrorAlertProps {
   error: {
     message: string;
-    type: ErrorType;
+    type: ErrorCode;
   };
 }
 
@@ -23,9 +23,14 @@ export function ErrorAlert({ error }: ErrorAlertProps) {
     case 'API_ERROR':
       title = 'Analysis Failed';
       break;
-    case 'RATE_LIMIT':
-      title = 'Too Many Requests';
-      description = 'Please wait a moment before trying again.';
+    case 'TEXT_PROCESSING_ERROR':
+      title = 'Processing Error';
+      break;
+    case 'CONFIGURATION_ERROR':
+      title = 'Configuration Error';
+      break;
+    case 'UNKNOWN_ERROR':
+      title = 'Unexpected Error';
       break;
   }
 

--- a/components/contract-analyzer/components/error-alert.tsx
+++ b/components/contract-analyzer/components/error-alert.tsx
@@ -1,11 +1,11 @@
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import type { ErrorCode } from '@/lib/errors';
+import type { ErrorType } from '@/lib/errors';
 
 interface ErrorAlertProps {
   error: {
     message: string;
-    type: ErrorCode;
+    type: ErrorType;
   };
 }
 
@@ -23,14 +23,9 @@ export function ErrorAlert({ error }: ErrorAlertProps) {
     case 'API_ERROR':
       title = 'Analysis Failed';
       break;
-    case 'TEXT_PROCESSING_ERROR':
-      title = 'Processing Error';
-      break;
-    case 'CONFIGURATION_ERROR':
-      title = 'Configuration Error';
-      break;
-    case 'UNKNOWN_ERROR':
-      title = 'Unexpected Error';
+    case 'RATE_LIMIT':
+      title = 'Too Many Requests';
+      description = 'Please wait a moment before trying again.';
       break;
   }
 

--- a/components/contract-analyzer/components/error-alert.tsx
+++ b/components/contract-analyzer/components/error-alert.tsx
@@ -1,0 +1,39 @@
+import { AlertCircle } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import type { ErrorType } from '@/lib/errors';
+
+interface ErrorAlertProps {
+  error: {
+    message: string;
+    type: ErrorType;
+  };
+}
+
+export function ErrorAlert({ error }: ErrorAlertProps) {
+  let title = 'Error';
+  let description = error.message;
+
+  switch (error.type) {
+    case 'INVALID_INPUT':
+      title = 'Invalid Document';
+      break;
+    case 'INVALID_DOCUMENT_TYPE':
+      title = 'Unsupported Document Type';
+      break;
+    case 'API_ERROR':
+      title = 'Analysis Failed';
+      break;
+    case 'RATE_LIMIT':
+      title = 'Too Many Requests';
+      description = 'Please wait a moment before trying again.';
+      break;
+  }
+
+  return (
+    <Alert variant="destructive" className="mb-4">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+    </Alert>
+  );
+}

--- a/components/contract-analyzer/hooks/analysis/useContractAnalysis.ts
+++ b/components/contract-analyzer/hooks/analysis/useContractAnalysis.ts
@@ -3,7 +3,8 @@ import * as Sentry from '@sentry/nextjs';
 import { trackAnalysis, startAnalyticsTransaction, captureError } from '../../utils/analytics';
 import { processFile } from '../../utils/text-processing';
 import { detectDocumentType } from '@/app/actions/detectDocumentType';
-import type { AnalysisState, AnalysisStreamResponse } from '../../types';
+import type { AnalysisState, AnalysisStreamResponse } from '../types';
+import type { ErrorCode } from '@/lib/errors';
 
 export interface UseContractAnalysisOptions {
   onStatusUpdate?: (status: string) => void;
@@ -95,7 +96,7 @@ export const useContractAnalysis = (options: UseContractAnalysisOptions = {}) =>
     if (!file) {
       setState(prev => ({
         ...prev,
-        error: { message: 'Please upload a file before analyzing.', type: 'warning' }
+        error: { message: 'Please upload a file before analyzing.', type: 'INVALID_INPUT' as ErrorCode }
       }));
       return;
     }
@@ -195,7 +196,9 @@ export const useContractAnalysis = (options: UseContractAnalysisOptions = {}) =>
         ...prev,
         error: { 
           message: error instanceof Error ? error.message : 'An unexpected error occurred', 
-          type: error instanceof Error && error.message.includes('appears to be a') ? 'INVALID_DOCUMENT_TYPE' : 'error'
+          type: error instanceof Error && error.message.includes('appears to be a') ? 
+            'INVALID_DOCUMENT_TYPE' as ErrorCode : 
+            'UNKNOWN_ERROR' as ErrorCode
         },
         progress: 0,
         stage: 'preprocessing',

--- a/components/contract-analyzer/hooks/analysis/useContractAnalysis.ts
+++ b/components/contract-analyzer/hooks/analysis/useContractAnalysis.ts
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import { trackAnalysis, startAnalyticsTransaction, captureError } from '../../utils/analytics';
 import { processFile } from '../../utils/text-processing';
-import { detectDocumentType } from '@/lib/document-type';
+import { detectDocumentType } from '@/app/actions/detectDocumentType';
 import type { AnalysisState, AnalysisStreamResponse } from '../../types';
 
 export interface UseContractAnalysisOptions {

--- a/components/contract-analyzer/hooks/types.ts
+++ b/components/contract-analyzer/hooks/types.ts
@@ -1,0 +1,26 @@
+import type { ErrorCode } from '@/lib/errors';
+
+export interface AnalysisState {
+  analysis: any | null;
+  isAnalyzing: boolean;
+  error: {
+    message: string;
+    type: ErrorCode;
+  } | null;
+  progress: number;
+  stage: 'preprocessing' | 'analyzing' | 'complete';
+  sectionsAnalyzed: number;
+  totalChunks: number;
+}
+
+export interface AnalysisStreamResponse {
+  type: 'update' | 'complete' | 'error';
+  error?: string;
+  result?: any;
+  progress?: number;
+  stage?: string;
+  activity?: string;
+  description?: string;
+  currentChunk?: number;
+  totalChunks?: number;
+}

--- a/components/contract-analyzer/hooks/types.ts
+++ b/components/contract-analyzer/hooks/types.ts
@@ -1,5 +1,7 @@
 import type { ErrorCode } from '@/lib/errors';
 
+export type AnalysisStage = 'preprocessing' | 'analyzing' | 'complete';
+
 export interface AnalysisState {
   analysis: any | null;
   isAnalyzing: boolean;
@@ -8,7 +10,7 @@ export interface AnalysisState {
     type: ErrorCode;
   } | null;
   progress: number;
-  stage: 'preprocessing' | 'analyzing' | 'complete';
+  stage: AnalysisStage;
   sectionsAnalyzed: number;
   totalChunks: number;
 }
@@ -18,7 +20,7 @@ export interface AnalysisStreamResponse {
   error?: string;
   result?: any;
   progress?: number;
-  stage?: string;
+  stage?: AnalysisStage;
   activity?: string;
   description?: string;
   currentChunk?: number;

--- a/components/contract-analyzer/hooks/useContractAnalyzer.ts
+++ b/components/contract-analyzer/hooks/useContractAnalyzer.ts
@@ -27,6 +27,7 @@ export const useContractAnalyzer = () => {
     handleFileSelect: baseHandleFileSelect,
     handleStartAnalysis,
     handleSelectStoredAnalysis: baseHandleSelectStoredAnalysis,
+    setError
   } = useAnalyzerState();
 
   // Analysis history
@@ -40,11 +41,18 @@ export const useContractAnalyzer = () => {
     }
   });
 
+  // Error handling
+  const handleClearError = useCallback(() => {
+    setError(null);
+    results.hide();
+  }, [setError, results]);
+
   // File selection handler
   const handleFileSelect = useCallback(async (newFile: File | null) => {
     results.hide();
+    handleClearError();
     await baseHandleFileSelect(newFile);
-  }, [baseHandleFileSelect, results]);
+  }, [baseHandleFileSelect, results, handleClearError]);
 
   // Analysis completion handler
   const handleAnalysisComplete = useCallback(async () => {
@@ -73,16 +81,18 @@ export const useContractAnalyzer = () => {
   const wrappedHandleStartAnalysis = useCallback(async () => {
     analysisHandledRef.current = false;
     resultClosedByUserRef.current = false;
+    handleClearError();
     await handleStartAnalysis();
-  }, [handleStartAnalysis]);
+  }, [handleStartAnalysis, handleClearError]);
 
   // Select stored analysis
   const handleSelectStoredAnalysis = useCallback(async (stored: StoredAnalysis) => {
     resultClosedByUserRef.current = false;
     lastSelectedAnalysisIdRef.current = stored.id;
+    handleClearError();
     baseHandleSelectStoredAnalysis(stored);
     results.show();
-  }, [baseHandleSelectStoredAnalysis, results]);
+  }, [baseHandleSelectStoredAnalysis, results, handleClearError]);
 
   // Effect for analysis completion
   useEffect(() => {
@@ -94,6 +104,13 @@ export const useContractAnalyzer = () => {
       handleAnalysisComplete();
     }
   }, [analysis, isAnalyzing, stage, file, handleAnalysisComplete]);
+
+  // Effect for error handling
+  useEffect(() => {
+    if (error) {
+      results.show();
+    }
+  }, [error, results]);
 
   return {
     // State
@@ -140,7 +157,8 @@ export const useContractAnalyzer = () => {
       handleFileSelect,
       handleStartAnalysis: wrappedHandleStartAnalysis,
       handleSelectStoredAnalysis,
-      handleAnalysisComplete
+      handleAnalysisComplete,
+      handleClearError
     }
   };
 };

--- a/components/error/ErrorDisplay.tsx
+++ b/components/error/ErrorDisplay.tsx
@@ -17,7 +17,7 @@ export function ErrorDisplay({ error }: ErrorDisplayProps) {
   let showSupportedTypes = false;
 
   // Customize based on error type
-  switch (error?.code) {
+  switch (error?.type || error?.code) {
     case 'INVALID_DOCUMENT_TYPE':
       title = 'Cannot Analyze Document';
       description = error.message || 'This document type is not supported for analysis.';
@@ -102,10 +102,28 @@ export function ErrorDisplay({ error }: ErrorDisplayProps) {
       </Alert>
 
       {showSupportedTypes && (
-        <div className="bg-muted/50 rounded-lg p-6">
-          <h3 className="text-lg font-medium text-center mb-4">
-            This tool analyzes legal documents such as contracts, NDAs, terms of service, and other legal agreements.
+        <div className="bg-muted/50 rounded-lg p-6 dark:bg-gray-800/50">
+          <h3 className="text-lg font-medium text-center mb-4 dark:text-gray-100">
+            This tool analyzes legal documents such as:
           </h3>
+          <ul className="list-none space-y-2">
+            <li className="flex items-center justify-center gap-2">
+              <span className="text-muted-foreground dark:text-gray-500">•</span>
+              <span className="dark:text-gray-300">Contracts and Agreements</span>
+            </li>
+            <li className="flex items-center justify-center gap-2">
+              <span className="text-muted-foreground dark:text-gray-500">•</span>
+              <span className="dark:text-gray-300">NDAs and Confidentiality Agreements</span>
+            </li>
+            <li className="flex items-center justify-center gap-2">
+              <span className="text-muted-foreground dark:text-gray-500">•</span>
+              <span className="dark:text-gray-300">Terms of Service</span>
+            </li>
+            <li className="flex items-center justify-center gap-2">
+              <span className="text-muted-foreground dark:text-gray-500">•</span>
+              <span className="dark:text-gray-300">Legal Policies and Procedures</span>
+            </li>
+          </ul>
         </div>
       )}
     </div>

--- a/components/error/ErrorDisplay.tsx
+++ b/components/error/ErrorDisplay.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertCircle, Clock, Ban, AlertTriangle, ServerCrash } from 'lucide-react';
+import { AlertCircle, Clock, Ban, AlertTriangle, ServerCrash, FileX } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ErrorDisplayProps {
@@ -14,9 +14,18 @@ export function ErrorDisplay({ error }: ErrorDisplayProps) {
   let description = 'An unexpected error occurred. Please try again.';
   let icon = AlertCircle;
   let variant: AlertVariant = 'destructive';
+  let showSupportedTypes = false;
 
   // Customize based on error type
   switch (error?.code) {
+    case 'INVALID_DOCUMENT_TYPE':
+      title = 'Cannot Analyze Document';
+      description = error.message || 'This document type is not supported for analysis.';
+      icon = FileX;
+      variant = 'destructive';
+      showSupportedTypes = true;
+      break;
+
     case 'CIRCUIT_BREAKER_OPEN':
       title = 'Service Temporarily Unavailable';
       description = error.clientMessage || 'Service is recovering. Please try again later.';
@@ -70,23 +79,35 @@ export function ErrorDisplay({ error }: ErrorDisplayProps) {
   const Icon = icon;
 
   return (
-    <Alert 
-      variant={variant}
-      className={cn(
-        "mt-4",
-        variant === 'default' && "border-yellow-200 bg-yellow-50 text-yellow-900 [&>svg]:text-yellow-900 dark:border-yellow-900/50 dark:bg-yellow-900/10 dark:text-yellow-100 dark:[&>svg]:text-yellow-100",
-        variant === 'destructive' && "border-red-200 bg-red-50 text-red-900 [&>svg]:text-red-900 dark:border-red-900/50 dark:bg-red-900/10 dark:text-red-100 dark:[&>svg]:text-red-100"
+    <div className="w-full max-w-2xl mx-auto space-y-4">
+      <Alert 
+        variant={variant}
+        className={cn(
+          "border-2",
+          variant === 'default' && "border-yellow-200 bg-yellow-50 text-yellow-900 [&>svg]:text-yellow-900 dark:border-yellow-900/50 dark:bg-yellow-900/10 dark:text-yellow-100 dark:[&>svg]:text-yellow-100",
+          variant === 'destructive' && "border-red-200 bg-red-50 text-red-900 [&>svg]:text-red-900 dark:border-red-900/50 dark:bg-red-900/10 dark:text-red-100 dark:[&>svg]:text-red-100"
+        )}
+      >
+        <Icon className="h-5 w-5" />
+        <AlertTitle className={cn(
+          "text-lg font-semibold mb-2",
+          variant === 'default' && "text-yellow-900 dark:text-yellow-100",
+          variant === 'destructive' && "text-red-900 dark:text-red-100"
+        )}>{title}</AlertTitle>
+        <AlertDescription className={cn(
+          "text-base",
+          variant === 'default' && "text-yellow-800/90 dark:text-yellow-100/90",
+          variant === 'destructive' && "text-red-800/90 dark:text-red-100/90"
+        )}>{description}</AlertDescription>
+      </Alert>
+
+      {showSupportedTypes && (
+        <div className="bg-muted/50 rounded-lg p-6">
+          <h3 className="text-lg font-medium text-center mb-4">
+            This tool analyzes legal documents such as contracts, NDAs, terms of service, and other legal agreements.
+          </h3>
+        </div>
       )}
-    >
-      <Icon className="h-4 w-4" />
-      <AlertTitle className={cn(
-        variant === 'default' && "text-yellow-900 dark:text-yellow-100",
-        variant === 'destructive' && "text-red-900 dark:text-red-100"
-      )}>{title}</AlertTitle>
-      <AlertDescription className={cn(
-        variant === 'default' && "text-yellow-800/90 dark:text-yellow-100/90",
-        variant === 'destructive' && "text-red-800/90 dark:text-red-100/90"
-      )}>{description}</AlertDescription>
-    </Alert>
+    </div>
   );
 }

--- a/components/shared/UnsupportedDocumentMessage.tsx
+++ b/components/shared/UnsupportedDocumentMessage.tsx
@@ -1,0 +1,35 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { FileX } from 'lucide-react';
+
+interface UnsupportedDocumentMessageProps {
+  documentType?: string;
+  explanation: string;
+}
+
+export function UnsupportedDocumentMessage({
+  documentType,
+  explanation
+}: UnsupportedDocumentMessageProps) {
+  return (
+    <div className="w-full max-w-2xl mx-auto space-y-4">
+      <Alert variant="destructive" className="border-2">
+        <FileX className="h-5 w-5" />
+        <AlertTitle className="text-lg font-semibold mb-2">
+          Cannot Analyze Document
+        </AlertTitle>
+        <AlertDescription className="text-base">
+          {documentType 
+            ? `This appears to be a ${documentType}: ${explanation}`
+            : explanation
+          }
+        </AlertDescription>
+      </Alert>
+
+      <div className="bg-muted/50 rounded-lg p-6">
+        <h3 className="text-lg font-medium text-center mb-4">
+          This tool analyzes legal documents such as contracts, NDAs, terms of service, and other legal agreements.
+        </h3>
+      </div>
+    </div>
+  );
+}

--- a/lib/document-type.ts
+++ b/lib/document-type.ts
@@ -1,0 +1,52 @@
+import { ContractAnalysisError } from "./errors";
+import { openAIService } from "./services/openai/openai-service";
+import { promptManager } from "./services/prompts";
+import type { DocumentTypeResponse } from "./services/prompts/types";
+
+export async function detectDocumentType(text: string): Promise<DocumentTypeResponse> {
+  // Take a sample from the start of the document for classification
+  const sampleText = text.slice(0, 3000);
+
+  const [typePrompt, config] = await Promise.all([
+    promptManager.getPrompt('document-type', { text: sampleText }),
+    promptManager.getModelConfig('documentType')
+  ]);
+
+  const response = await openAIService.createChatCompletion({
+    model: config.model,
+    temperature: config.temperature,
+    max_tokens: config.max_tokens,
+    response_format: config.response_format,
+    messages: [
+      { role: "user", content: typePrompt }
+    ],
+    stream: false
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new ContractAnalysisError('Document type detection failed', 'API_ERROR');
+  }
+
+  try {
+    const result = JSON.parse(content) as DocumentTypeResponse;
+    
+    // Validate the response structure
+    if (
+      typeof result.isLegalDocument !== 'boolean' ||
+      typeof result.documentType !== 'string' ||
+      typeof result.confidence !== 'number' ||
+      typeof result.explanation !== 'string' ||
+      !['proceed_with_analysis', 'stop_analysis'].includes(result.recommendedAction)
+    ) {
+      throw new Error('Invalid response structure');
+    }
+
+    return result;
+  } catch (error) {
+    throw new ContractAnalysisError(
+      'Failed to parse document type detection response',
+      'API_ERROR'
+    );
+  }
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -9,7 +9,8 @@ export type ErrorCode =
   | 'INVALID_INPUT'
   | 'TEXT_PROCESSING_ERROR'
   | 'UNKNOWN_ERROR'
-  | 'CONFIGURATION_ERROR';
+  | 'CONFIGURATION_ERROR'
+  | 'INVALID_DOCUMENT_TYPE';
 
 export class BaseError extends Error {
   constructor(message: string, public code: ErrorCode, public cause?: unknown) {
@@ -32,7 +33,13 @@ export class PDFProcessingError extends BaseError {
 export class ContractAnalysisError extends BaseError {
   constructor(
     message: string,
-    code: Extract<ErrorCode, 'API_ERROR' | 'INVALID_INPUT' | 'TEXT_PROCESSING_ERROR' | 'UNKNOWN_ERROR' | 'CONFIGURATION_ERROR'>,
+    code: Extract<ErrorCode, 
+      | 'API_ERROR' 
+      | 'INVALID_INPUT' 
+      | 'TEXT_PROCESSING_ERROR' 
+      | 'UNKNOWN_ERROR' 
+      | 'CONFIGURATION_ERROR'
+      | 'INVALID_DOCUMENT_TYPE'>,
     cause?: unknown
   ) {
     super(message, code, cause);

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -10,7 +10,8 @@ export type ErrorCode =
   | 'TEXT_PROCESSING_ERROR'
   | 'UNKNOWN_ERROR'
   | 'CONFIGURATION_ERROR'
-  | 'INVALID_DOCUMENT_TYPE';
+  | 'INVALID_DOCUMENT_TYPE'  // Only adding this one new type
+  | 'RATE_LIMIT';  // Keeping existing types
 
 export class BaseError extends Error {
   constructor(message: string, public code: ErrorCode, public cause?: unknown) {
@@ -39,7 +40,8 @@ export class ContractAnalysisError extends BaseError {
       | 'TEXT_PROCESSING_ERROR' 
       | 'UNKNOWN_ERROR' 
       | 'CONFIGURATION_ERROR'
-      | 'INVALID_DOCUMENT_TYPE'>,
+      | 'INVALID_DOCUMENT_TYPE'  // Only adding this new type
+      | 'RATE_LIMIT'>,  // Keeping existing types
     cause?: unknown
   ) {
     super(message, code, cause);

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -10,8 +10,11 @@ export type ErrorCode =
   | 'TEXT_PROCESSING_ERROR'
   | 'UNKNOWN_ERROR'
   | 'CONFIGURATION_ERROR'
-  | 'INVALID_DOCUMENT_TYPE'  // Only adding this one new type
-  | 'RATE_LIMIT';  // Keeping existing types
+  | 'INVALID_DOCUMENT_TYPE'
+  | 'RATE_LIMIT';
+
+// Export ErrorCode as ErrorType for backward compatibility
+export type ErrorType = ErrorCode;
 
 export class BaseError extends Error {
   constructor(message: string, public code: ErrorCode, public cause?: unknown) {
@@ -40,8 +43,8 @@ export class ContractAnalysisError extends BaseError {
       | 'TEXT_PROCESSING_ERROR' 
       | 'UNKNOWN_ERROR' 
       | 'CONFIGURATION_ERROR'
-      | 'INVALID_DOCUMENT_TYPE'  // Only adding this new type
-      | 'RATE_LIMIT'>,  // Keeping existing types
+      | 'INVALID_DOCUMENT_TYPE'
+      | 'RATE_LIMIT'>,
     cause?: unknown
   ) {
     super(message, code, cause);

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -13,9 +13,6 @@ export type ErrorCode =
   | 'INVALID_DOCUMENT_TYPE'
   | 'RATE_LIMIT';
 
-// Export ErrorCode as ErrorType for backward compatibility
-export type ErrorType = ErrorCode;
-
 export class BaseError extends Error {
   constructor(message: string, public code: ErrorCode, public cause?: unknown) {
     super(message);

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,0 +1,37 @@
+export type ErrorType =
+  | 'API_ERROR'
+  | 'INVALID_INPUT'
+  | 'INVALID_DOCUMENT_TYPE'
+  | 'RATE_LIMIT'
+  | 'UNKNOWN';
+
+export class ContractAnalysisError extends Error {
+  type: ErrorType;
+
+  constructor(message: string, type: ErrorType) {
+    super(message);
+    this.type = type;
+    this.name = 'ContractAnalysisError';
+  }
+}
+
+export function getErrorMessage(error: unknown): { message: string; type: ErrorType } {
+  if (error instanceof ContractAnalysisError) {
+    return {
+      message: error.message,
+      type: error.type
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      type: 'UNKNOWN'
+    };
+  }
+
+  return {
+    message: 'An unexpected error occurred',
+    type: 'UNKNOWN'
+  };
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,9 +1,10 @@
 export type ErrorType =
   | 'API_ERROR'
   | 'INVALID_INPUT'
-  | 'INVALID_DOCUMENT_TYPE'
-  | 'RATE_LIMIT'
-  | 'UNKNOWN';
+  | 'TEXT_PROCESSING_ERROR'
+  | 'UNKNOWN_ERROR'
+  | 'CONFIGURATION_ERROR'
+  | 'INVALID_DOCUMENT_TYPE';  // Added this new type
 
 export class ContractAnalysisError extends Error {
   type: ErrorType;
@@ -26,12 +27,12 @@ export function getErrorMessage(error: unknown): { message: string; type: ErrorT
   if (error instanceof Error) {
     return {
       message: error.message,
-      type: 'UNKNOWN'
+      type: 'UNKNOWN_ERROR'
     };
   }
 
   return {
     message: 'An unexpected error occurred',
-    type: 'UNKNOWN'
+    type: 'UNKNOWN_ERROR'
   };
 }

--- a/lib/services/prompts/config.ts
+++ b/lib/services/prompts/config.ts
@@ -17,5 +17,13 @@ export const modelConfigs: Record<string, ModelConfig> = {
     response_format: {
       type: "text"
     }
+  },
+  documentType: {
+    model: "gpt-3.5-turbo-1106",
+    temperature: 0.3,
+    max_tokens: 500,
+    response_format: {
+      type: "json_object"
+    }
   }
 } as const;  // Make it readonly with literal types

--- a/lib/services/prompts/templates.ts
+++ b/lib/services/prompts/templates.ts
@@ -1,0 +1,134 @@
+export const templates = {
+  system: `You are an experienced legal expert specializing in contract analysis and risk assessment. Your role is to:
+
+1. Identify potential risks and red flags that could negatively impact the user
+2. Highlight critical clauses that require immediate attention or negotiation
+3. Provide actionable recommendations for protecting user's interests
+4. Offer clear, practical steps for negotiation or risk mitigation
+
+Guidelines for analysis:
+- Focus on substantial risks and critical deadlines
+- Prioritize business impact and practical implications
+- Identify ambiguous or problematic language
+- Flag missing standard protections
+- Note unusual or particularly onerous terms
+- Consider both immediate and long-term implications
+- Highlight key dates and deadlines
+- Focus on actionable insights`,
+
+  summary: `You are a specialized document classifier and summarizer. First, identify the type of document, then provide a summary appropriate to its type.
+
+For legal documents (contracts, agreements, NDAs, etc.):
+Begin with: "This is a [contract type] between [parties] for [purpose]."
+Include the main terms, parties, and key obligations.
+
+For financial documents (payslips, invoices, statements):
+Begin with: "This is a [document type] showing [main financial purpose]."
+DO NOT try to interpret it as a contract.
+
+For other documents (recipes, manuals, articles, etc.):
+Begin with: "This is a [document type] about [subject]."
+Provide a brief content summary appropriate to the document type.
+
+Guidelines:
+1. Never force a non-legal document into a contract format
+2. Be explicit about document type identification
+3. Keep summaries concise and relevant to document type
+4. For non-legal documents, explain why it's not suitable for contract analysis
+
+Text to analyze:
+
+{{text}}`,
+
+  'document-type': `You are a specialized document classifier focused on identifying legal documents and contracts. Your task is to analyze the provided text and determine with high confidence whether it is a legal document suitable for contract analysis.
+
+Step 1: Document Structure Analysis
+Check for these key structural elements:
+- Title or heading indicating legal nature
+- Defined parties section
+- Numbered or lettered sections
+- Signature blocks or execution sections
+- Dated elements and formal formatting
+
+Step 2: Content Verification
+Look for these essential legal elements:
+- Rights and obligations language
+- Legal terminology and definitions
+- Consideration or value exchange
+- Term or duration specifications
+- Governing law or jurisdiction
+
+Step 3: Non-Legal Document Indicators
+Be alert for these typical non-legal document characteristics:
+- Financial statements or calculations (payslips, invoices)
+- Technical instructions or manuals
+- Marketing or promotional content
+- Personal communications
+- Recipes or how-to guides
+- Meeting notes or minutes
+- Medical records or reports
+- Academic papers or articles
+
+Provide your analysis in this JSON format:
+{
+  "isLegalDocument": boolean,
+  "documentType": string,
+  "confidence": number (0-1),
+  "identifiedElements": {
+    "hasTitle": boolean,
+    "hasParties": boolean,
+    "hasNumberedSections": boolean,
+    "hasSignatureBlocks": boolean,
+    "hasLegalTerminology": boolean,
+    "hasRightsObligations": boolean
+  },
+  "explanation": string (explain why this is or isn't a legal document),
+  "recommendedAction": "proceed_with_analysis" | "stop_analysis"
+}
+
+Rules:
+1. Set isLegalDocument=true ONLY if:
+   - Confidence is 0.9 or higher
+   - At least 4 legal elements are identified
+   - Document clearly serves a legal purpose
+2. For non-legal documents:
+   - Provide clear explanation why it's not suitable
+   - Include specific document type identified
+   - Set recommendedAction to "stop_analysis"
+3. For ambiguous cases:
+   - Default to non-legal classification
+   - Explain specific missing elements
+   - Suggest proper document type if known
+
+Analyze this text:
+{{text}}`,
+
+  analysis: `Section {{chunkIndex}}/{{totalChunks}}:
+
+{{chunk}}
+
+Provide a JSON response with the following structure:
+
+{
+  "potentialRisks": [
+    "Specific issues that could negatively impact the user",
+    "Ambiguous or unfavorable terms",
+    "Missing protections or guarantees",
+    "Unusual or excessive obligations",
+    "Compliance or operational challenges"
+  ],
+  "importantClauses": [
+    "Critical deadlines and important dates",
+    "Key financial obligations or requirements",
+    "Significant limitations or exclusions",
+    "Performance requirements and metrics"
+  ],
+  "recommendations": [
+    "Specific negotiation points with suggested changes",
+    "Risk mitigation strategies",
+    "Required clarifications or additions",
+    "Suggested additional protections",
+    "Practical next steps"
+  ]
+}`
+};

--- a/lib/services/prompts/types.ts
+++ b/lib/services/prompts/types.ts
@@ -19,15 +19,25 @@ export interface PromptVariables {
   [key: string]: string | undefined;
 }
 
-export type AnalysisType = 'analysis' | 'summary' | 'documentType';
+export interface LegalElements {
+  hasTitle: boolean;
+  hasParties: boolean;
+  hasNumberedSections: boolean;
+  hasSignatureBlocks: boolean;
+  hasLegalTerminology: boolean;
+  hasRightsObligations: boolean;
+}
 
 export interface DocumentTypeResponse {
   isLegalDocument: boolean;
   documentType: string;
   confidence: number;
+  identifiedElements: LegalElements;
   explanation: string;
   recommendedAction: 'proceed_with_analysis' | 'stop_analysis';
 }
+
+export type AnalysisType = 'analysis' | 'summary' | 'documentType';
 
 export interface PromptManager {
   getPrompt(type: PromptType, variables?: PromptVariables): Promise<string>;

--- a/lib/services/prompts/types.ts
+++ b/lib/services/prompts/types.ts
@@ -41,6 +41,6 @@ export type AnalysisType = 'analysis' | 'summary' | 'documentType';
 
 export interface PromptManager {
   getPrompt(type: PromptType, variables?: PromptVariables): Promise<string>;
-  getModelConfig(type: AnalysisType): Promise<ModelConfig>;
+  getModelConfig(type: AnalysisType): ModelConfig;
   clearCache(): void;
 }

--- a/lib/services/prompts/types.ts
+++ b/lib/services/prompts/types.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
 
-export type PromptType = 'system' | 'summary' | 'analysis';
+export type PromptType = 'system' | 'summary' | 'analysis' | 'document-type';
 
 export interface ModelConfig {
   model: ChatCompletionCreateParamsNonStreaming['model'];
@@ -15,10 +15,19 @@ export interface PromptVariables {
   chunk?: string;
   chunkIndex?: string;
   totalChunks?: string;
+  text?: string;
   [key: string]: string | undefined;
 }
 
-export type AnalysisType = 'analysis' | 'summary';
+export type AnalysisType = 'analysis' | 'summary' | 'documentType';
+
+export interface DocumentTypeResponse {
+  isLegalDocument: boolean;
+  documentType: string;
+  confidence: number;
+  explanation: string;
+  recommendedAction: 'proceed_with_analysis' | 'stop_analysis';
+}
 
 export interface PromptManager {
   getPrompt(type: PromptType, variables?: PromptVariables): Promise<string>;

--- a/prompts/config/models.json
+++ b/prompts/config/models.json
@@ -4,7 +4,7 @@
     "temperature": 0.3,
     "max_tokens": 1000,
     "response_format": {
-      "type": "json_object" as "json_object"
+      "type": "json_object"
     }
   },
   "summary": {
@@ -12,7 +12,15 @@
     "temperature": 0.3,
     "max_tokens": 300,
     "response_format": {
-      "type": "text" as "text"
+      "type": "text"
+    }
+  },
+  "documentType": {
+    "model": "gpt-3.5-turbo-1106",
+    "temperature": 0.3,
+    "max_tokens": 500,
+    "response_format": {
+      "type": "json_object"
     }
   }
 }

--- a/prompts/templates/document-type.txt
+++ b/prompts/templates/document-type.txt
@@ -1,0 +1,33 @@
+Analyze the following text to determine if it is a legal document or contract. If it is, identify its specific type. If it's not, explain what kind of document it appears to be.
+
+Provide your response in JSON format:
+{
+  "isLegalDocument": boolean,
+  "documentType": string,
+  "confidence": number (0-1),
+  "explanation": string,
+  "recommendedAction": string
+}
+
+Example responses:
+
+Legal document:
+{
+  "isLegalDocument": true,
+  "documentType": "Employment Contract",
+  "confidence": 0.95,
+  "explanation": "This is an employment agreement containing standard clauses for compensation, duties, and termination.",
+  "recommendedAction": "proceed_with_analysis"
+}
+
+Non-legal document:
+{
+  "isLegalDocument": false,
+  "documentType": "Technical Documentation",
+  "confidence": 0.88,
+  "explanation": "This appears to be a software user manual containing installation and usage instructions.",
+  "recommendedAction": "stop_analysis"
+}
+
+Analyze this text:
+{{text}}

--- a/prompts/templates/document-type.txt
+++ b/prompts/templates/document-type.txt
@@ -1,33 +1,62 @@
-Analyze the following text to determine if it is a legal document or contract. If it is, identify its specific type. If it's not, explain what kind of document it appears to be.
+You are a specialized document classifier focused on identifying legal documents and contracts. Your task is to analyze the provided text and determine with high confidence whether it is a legal document suitable for contract analysis.
 
-Provide your response in JSON format:
+Step 1: Document Structure Analysis
+Check for these key structural elements:
+- Title or heading indicating legal nature
+- Defined parties section
+- Numbered or lettered sections
+- Signature blocks or execution sections
+- Dated elements and formal formatting
+
+Step 2: Content Verification
+Look for these essential legal elements:
+- Rights and obligations language
+- Legal terminology and definitions
+- Consideration or value exchange
+- Term or duration specifications
+- Governing law or jurisdiction
+
+Step 3: Non-Legal Document Indicators
+Be alert for these typical non-legal document characteristics:
+- Financial statements or calculations (payslips, invoices)
+- Technical instructions or manuals
+- Marketing or promotional content
+- Personal communications
+- Recipes or how-to guides
+- Meeting notes or minutes
+- Medical records or reports
+- Academic papers or articles
+
+Provide your analysis in this JSON format:
 {
   "isLegalDocument": boolean,
   "documentType": string,
   "confidence": number (0-1),
-  "explanation": string,
-  "recommendedAction": string
+  "identifiedElements": {
+    "hasTitle": boolean,
+    "hasParties": boolean,
+    "hasNumberedSections": boolean,
+    "hasSignatureBlocks": boolean,
+    "hasLegalTerminology": boolean,
+    "hasRightsObligations": boolean
+  },
+  "explanation": string (explain why this is or isn't a legal document),
+  "recommendedAction": "proceed_with_analysis" | "stop_analysis"
 }
 
-Example responses:
-
-Legal document:
-{
-  "isLegalDocument": true,
-  "documentType": "Employment Contract",
-  "confidence": 0.95,
-  "explanation": "This is an employment agreement containing standard clauses for compensation, duties, and termination.",
-  "recommendedAction": "proceed_with_analysis"
-}
-
-Non-legal document:
-{
-  "isLegalDocument": false,
-  "documentType": "Technical Documentation",
-  "confidence": 0.88,
-  "explanation": "This appears to be a software user manual containing installation and usage instructions.",
-  "recommendedAction": "stop_analysis"
-}
+Rules:
+1. Set isLegalDocument=true ONLY if:
+   - Confidence is 0.9 or higher
+   - At least 4 legal elements are identified
+   - Document clearly serves a legal purpose
+2. For non-legal documents:
+   - Provide clear explanation why it's not suitable
+   - Include specific document type identified
+   - Set recommendedAction to "stop_analysis"
+3. For ambiguous cases:
+   - Default to non-legal classification
+   - Explain specific missing elements
+   - Suggest proper document type if known
 
 Analyze this text:
 {{text}}

--- a/prompts/templates/summary.txt
+++ b/prompts/templates/summary.txt
@@ -1,13 +1,23 @@
-Provide a factual description of the legal document, formatted as specified below.
+You are a specialized document classifier and summarizer. First, identify the type of document, then provide a summary appropriate to its type.
 
-Begin with:
-"This is a [type] between [parties] for [purpose]."
+For legal documents (contracts, agreements, NDAs, etc.):
+Begin with: "This is a [contract type] between [parties] for [purpose]."
+Include the main terms, parties, and key obligations.
 
-Include:
-- Document type
-- Primary parties
-- Core purpose
-- Key terms if significant
+For financial documents (payslips, invoices, statements):
+Begin with: "This is a [document type] showing [main financial purpose]."
+DO NOT try to interpret it as a contract.
 
-Example:
-"This is a software development agreement between TechCorp (Client) and DevPro LLC (Developer) for creating a custom CRM system. The Developer will deliver the system in 3 phases over 12 months, with the Client paying $150,000 in milestone-based installments."
+For other documents (recipes, manuals, articles, etc.):
+Begin with: "This is a [document type] about [subject]."
+Provide a brief content summary appropriate to the document type.
+
+Guidelines:
+1. Never force a non-legal document into a contract format
+2. Be explicit about document type identification
+3. Keep summaries concise and relevant to document type
+4. For non-legal documents, explain why it's not suitable for contract analysis
+
+Text to analyze:
+
+{{text}}


### PR DESCRIPTION
This PR standardizes our error handling type naming by:

1. Using `ErrorCode` consistently throughout the codebase
2. Removing the `ErrorType` alias that was added for compatibility
3. Updating components to use the standard `ErrorCode` type

Changes:
- Modified `error-alert.tsx` to use `ErrorCode`
- Updated `lib/errors.ts` to remove temporary alias
- Ensured all error codes are properly typed

This change:
- Makes the codebase more consistent
- Removes temporary compatibility code
- Has no functional changes (purely type improvements)

All existing error handling continues to work the same way - this is just a typing cleanup.